### PR TITLE
Update constraints.py

### DIFF
--- a/src/mqt/qao/constraints.py
+++ b/src/mqt/qao/constraints.py
@@ -55,6 +55,7 @@ class Constraints:
         bool -- for identifying eventual errors or issue in the conversion
         auxiliary_variables -- variable added for writing constraints
         """
+        self.constraints_penalty_functions = []
         auxiliary_variables = Variables()
         i = 0
         j = 0


### PR DESCRIPTION
Reset list of constraint penalty functions to avoid endless additions.

Repeated calls to `self.problem.update_lambda_cost_function` ([see](https://github.com/henrikarhula/mqt-qao/blob/f275b2706f8e791eee35c614dbbd9f3b663491ca/src/mqt/qao/solvers.py#L158)) cause the endless additions of constraint penalty functions ([see](https://github.com/henrikarhula/mqt-qao/blob/f275b2706f8e791eee35c614dbbd9f3b663491ca/src/mqt/qao/constraints.py#L95)) unless the list is emptied.

This will eventually cause an index error [here](https://github.com/henrikarhula/mqt-qao/blob/f275b2706f8e791eee35c614dbbd9f3b663491ca/src/mqt/qao/problem.py#L124) since there are too many constraint penalty functions.

The suggested fix simply resets the list of penalty functions at every call of `translate_constraints`.