### PR TITLE
added warning filter for qiskit 1.3 deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,10 @@ name = "mqt.qao"
 description = "MQT Quantum Auto Optimizer: Automatic Framework for Solving Optimization Problems with Quantum Computers"
 readme = "README.md"
 authors = [
-    { name = "Deborah Volpe", email = "deborah.volpe@polito.it"},
+    { name = "Deborah Volpe", email = "deborah.volpe@polito.it" },
     { name = "Nils Quetschlich", email = "nils.quetschlich@tum.de" },
 ]
-keywords = ["MQT",  "quantum-computing", "optimization", "QUBO"]
+keywords = ["MQT", "quantum-computing", "optimization", "QUBO"]
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 dynamic = ["version"]
@@ -85,22 +85,23 @@ addopts = ["-ra", "--strict-markers", "--strict-config", "--showlocals"]
 log_cli_level = "info"
 xfail_strict = true
 filterwarnings = [
-  "error",
-  "ignore:.*invalid escape sequence.*::.*docplex.*", # See https://github.com/cda-tum/mqt-qao/issues/3
-  "ignore:.*invalid escape sequence.*::.*dwave.*", # See https://github.com/cda-tum/mqt-qao/issues/3
-  "ignore:.*invalid escape sequence.*::.*homebase.*", # See https://github.com/cda-tum/mqt-qao/issues/3
-  "ignore:.*invalid escape sequence.*::.*plucky.*", # See https://github.com/cda-tum/mqt-qao/issues/3
-  "ignore:.*numpy.core.shape_base.*::", # See https://github.com/cda-tum/mqt-qao/issues/3
-  # The warning filters below are only temporary and should be removed once the usage of the Sampler and Estimator is updated
-  "ignore:.*BaseSamplerV1.*:DeprecationWarning:",
-  "ignore:.*BaseEstimatorV1.*:DeprecationWarning:",
-  'ignore:.*qiskit\.primitives\.utils.*:DeprecationWarning:',
-  # The RandomForest classifier has been trained with sklearn 1.4.1.post1, which might not be compatible with newer versions
-  'ignore:.*Trying to unpickle.*:sklearn.exceptions.InconsistentVersionWarning:',
-  'ignore:.*X does not have valid feature names.*:UserWarning:',
+    "error",
+    "ignore:.*invalid escape sequence.*::.*docplex.*", # See https://github.com/cda-tum/mqt-qao/issues/3
+    "ignore:.*invalid escape sequence.*::.*dwave.*", # See https://github.com/cda-tum/mqt-qao/issues/3
+    "ignore:.*invalid escape sequence.*::.*homebase.*", # See https://github.com/cda-tum/mqt-qao/issues/3
+    "ignore:.*invalid escape sequence.*::.*plucky.*", # See https://github.com/cda-tum/mqt-qao/issues/3
+    "ignore:.*numpy.core.shape_base.*::", # See https://github.com/cda-tum/mqt-qao/issues/3
+    # The warning filters below are only temporary and should be removed once the usage of the Sampler and Estimator is updated
+    "ignore:.*BaseSamplerV1.*:DeprecationWarning:",
+    "ignore:.*BaseEstimatorV1.*:DeprecationWarning:",
+    'ignore:.*qiskit\.primitives\.utils.*:DeprecationWarning:',
+    # The RandomForest classifier has been trained with sklearn 1.4.1.post1, which might not be compatible with newer versions
+    'ignore:.*Trying to unpickle.*:sklearn.exceptions.InconsistentVersionWarning:',
+    'ignore:.*X does not have valid feature names.*:UserWarning:',
     # Qiskit 1.3 deprecations
     'ignore:.*The property ``qiskit.dagcircuit.dagcircuit.DAGCircuit.*`` is deprecated as of qiskit 1.3.0.*:DeprecationWarning:qiskit.*',
     'ignore:.*The class ``qiskit.circuit.library.n_local.two_local.*`` is deprecated as of Qiskit 1.3.*:DeprecationWarning:qiskit.*',
+    'ignore:.*is pending deprecation as of qiskit 1.3..*:PendingDeprecationWarning:',
 ]
 
 
@@ -157,54 +158,54 @@ unsafe-fixes = true
 
 [tool.ruff.lint]
 extend-select = [
-    "A",           # flake8-builtins
-    "ANN",         # flake8-annotations
-    "ARG",         # flake8-unused-arguments
-    "ASYNC",       # flake8-async
-    "B",  "B904",  # flake8-bugbear
-    "C4",          # flake8-comprehensions
-#    "D",           # pydocstyle
-    "EM",          # flake8-errmsg
-    "EXE",         # flake8-executable
-    "FA",          # flake8-future-annotations
-    "FLY",         # flynt
-    "FURB",        # refurb
-    "I",           # isort
-    "ICN",         # flake8-import-conventions
-    "ISC",         # flake8-implicit-str-concat
-    "LOG",         # flake8-logging-format
-    "N",           # flake8-naming
-    "NPY",         # numpy
-    "PERF",        # perflint
-    "PGH",         # pygrep-hooks
-    "PIE",         # flake8-pie
-    "PL",          # pylint
-    "PT",          # flake8-pytest-style
-    "PTH",         # flake8-use-pathlib
-    "PYI",         # flake8-pyi
-    "Q",           # flake8-quotes
-    "RET",         # flake8-return
-    "RSE",         # flake8-raise
-    "RUF",         # Ruff-specific
-    "SLF",         # flake8-self
-    "SLOT",        # flake8-slots
-    "SIM",         # flake8-simplify
-    "TCH",         # flake8-type-checking
-    "TID251",      # flake8-tidy-imports.banned-api
-    "TRY",         # tryceratops
-    "UP",          # pyupgrade
-    "YTT",         # flake8-2020
+    "A", # flake8-builtins
+    "ANN", # flake8-annotations
+    "ARG", # flake8-unused-arguments
+    "ASYNC", # flake8-async
+    "B", "B904", # flake8-bugbear
+    "C4", # flake8-comprehensions
+    #    "D",           # pydocstyle
+    "EM", # flake8-errmsg
+    "EXE", # flake8-executable
+    "FA", # flake8-future-annotations
+    "FLY", # flynt
+    "FURB", # refurb
+    "I", # isort
+    "ICN", # flake8-import-conventions
+    "ISC", # flake8-implicit-str-concat
+    "LOG", # flake8-logging-format
+    "N", # flake8-naming
+    "NPY", # numpy
+    "PERF", # perflint
+    "PGH", # pygrep-hooks
+    "PIE", # flake8-pie
+    "PL", # pylint
+    "PT", # flake8-pytest-style
+    "PTH", # flake8-use-pathlib
+    "PYI", # flake8-pyi
+    "Q", # flake8-quotes
+    "RET", # flake8-return
+    "RSE", # flake8-raise
+    "RUF", # Ruff-specific
+    "SLF", # flake8-self
+    "SLOT", # flake8-slots
+    "SIM", # flake8-simplify
+    "TCH", # flake8-type-checking
+    "TID251", # flake8-tidy-imports.banned-api
+    "TRY", # tryceratops
+    "UP", # pyupgrade
+    "YTT", # flake8-2020
 ]
 ignore = [
-    "ANN101",  # Missing type annotation for `self` in method
-    "ANN102",  # Missing type annotation for `cls` in classmethod
-    "ISC001",  # Conflicts with formatter
-    "PLR09",   # Too many <...>
+    "ANN101", # Missing type annotation for `self` in method
+    "ANN102", # Missing type annotation for `cls` in classmethod
+    "ISC001", # Conflicts with formatter
+    "PLR09", # Too many <...>
     "PLR2004", # Magic value used in comparison
     "PLC0415", # Import should be at top of file
-    "PT004",   # Incorrect, just usefixtures instead.
-    "S101",    # Use of assert detected
-    "S404",    # `subprocess` module is possibly insecure
+    "PT004", # Incorrect, just usefixtures instead.
+    "S101", # Use of assert detected
+    "S404", # `subprocess` module is possibly insecure
 ]
 isort.required-imports = ["from __future__ import annotations"]
 
@@ -224,7 +225,7 @@ isort.required-imports = ["from __future__ import annotations"]
 "noxfile.py" = ["T20", "TID251"]
 "*.pyi" = ["D418", "PYI021"]  # pydocstyle
 "*.ipynb" = [
-    "D",    # pydocstyle
+    "D", # pydocstyle
     "E402", # Allow imports to appear anywhere in Jupyter notebooks
     "I002", # Allow missing `from __future__ import annotations` import
 ]
@@ -235,7 +236,7 @@ convention = "google"
 
 [tool.typos]
 default.extend-ignore-re = [
-    "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$",  # ignore line
+    "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$", # ignore line
     "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on" # ignore block
 ]
 default.extend-ignore-identifiers-re = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ filterwarnings = [
   # The RandomForest classifier has been trained with sklearn 1.4.1.post1, which might not be compatible with newer versions
   'ignore:.*Trying to unpickle.*:sklearn.exceptions.InconsistentVersionWarning:',
   'ignore:.*X does not have valid feature names.*:UserWarning:',
+  'ignore:.* deprecation as of qiskit 1.3*.:PendingDeprecationWarning:qiskit.*',
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,8 @@ filterwarnings = [
   # The RandomForest classifier has been trained with sklearn 1.4.1.post1, which might not be compatible with newer versions
   'ignore:.*Trying to unpickle.*:sklearn.exceptions.InconsistentVersionWarning:',
   'ignore:.*X does not have valid feature names.*:UserWarning:',
-  'ignore:.* deprecation as of qiskit 1.3*.:PendingDeprecationWarning:qiskit.*',
+  'ignore:.*deprecation as of qiskit 1\.3*:PendingDeprecationWarning:qiskit.*',
+  'ignore:.*deprecation as of qiskit 1\.3*:DeprecationWarning:qiskit.*',
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,8 +98,9 @@ filterwarnings = [
   # The RandomForest classifier has been trained with sklearn 1.4.1.post1, which might not be compatible with newer versions
   'ignore:.*Trying to unpickle.*:sklearn.exceptions.InconsistentVersionWarning:',
   'ignore:.*X does not have valid feature names.*:UserWarning:',
-  'ignore:.*deprecation as of qiskit 1\.3*:PendingDeprecationWarning:qiskit.*',
-  'ignore:.*deprecation as of qiskit 1\.3*:DeprecationWarning:qiskit.*',
+    # Qiskit 1.3 deprecations
+    'ignore:.*The property ``qiskit.dagcircuit.dagcircuit.DAGCircuit.*`` is deprecated as of qiskit 1.3.0.*:DeprecationWarning:qiskit.*',
+    'ignore:.*The class ``qiskit.circuit.library.n_local.two_local.*`` is deprecated as of Qiskit 1.3.*:DeprecationWarning:qiskit.*',
 ]
 
 


### PR DESCRIPTION
The Qiskit 1.3.0 release introduces some `DeprecationWarnings` for functions that will be removed in Qiskit 2.0.0. For now, I excluded these warnings as a temporary fix to make the CI happy. But I would be good if you, @DeborahVolpe, could try to make fix the underlying cause here whenever you have time.