### PR TITLE
Improved robustness and support of various (uncommon) variable names

### DIFF
--- a/src/mqt/qao/objectivefunction.py
+++ b/src/mqt/qao/objectivefunction.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
 import re
+from typing import TYPE_CHECKING, Any, cast
 
 # for managing symbols
 from sympy import Expr, expand
@@ -155,7 +155,9 @@ class ObjectiveFunction:
         for obj in self.objective_functions:
             obj_str = str(obj[0])
             obj_str = obj_str.replace("**", "^")
-            fields = [x.strip() for x in re.split('([+-])', obj_str)]  # split by + and - signs and strip trailing and leading whitespaces
+            fields = [
+                x.strip() for x in re.split(r"([+-])", obj_str)
+            ]  # split by + and - signs and strip trailing and leading whitespaces
             fields = filter(None, fields)  # filter out empty strings possibly created by re.split
             func = 0.0
             sign = "+"

--- a/src/mqt/qao/objectivefunction.py
+++ b/src/mqt/qao/objectivefunction.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
+import re
 
 # for managing symbols
 from sympy import Expr, expand
@@ -153,9 +154,9 @@ class ObjectiveFunction:
         """
         for obj in self.objective_functions:
             obj_str = str(obj[0])
-            if obj_str.startswith("-") and obj_str[1] != " ":
-                obj_str = obj_str[0] + " " + obj_str[1:]
-            fields = str(obj_str).replace("**", "^").split(" ")
+            obj_str = obj_str.replace("**", "^")
+            fields = [x.strip() for x in re.split('([+-])', obj_str)]  # split by + and - signs and strip trailing and leading whitespaces
+            fields = filter(None, fields)  # filter out empty strings possibly created by re.split
             func = 0.0
             sign = "+"
             for field in fields:

--- a/src/mqt/qao/variables.py
+++ b/src/mqt/qao/variables.py
@@ -10,7 +10,7 @@ import numpy as np
 from qubovert import boolean_var
 
 # for managing symbols
-from sympy import Symbol, expand, symbols
+from sympy import Symbol, expand
 
 
 class Variables:
@@ -597,7 +597,7 @@ class Variable:
         binary_variables_name_weight[self.name].append("dictionary")
         for val in values:
             binary_variables_name_weight[self.name].append((boolean_var(letter + format(i)), val))
-            var_sum += symbols(letter + format(i))
+            var_sum += Symbol(letter + format(i))
             i += 1
 
         # Add the needed constraint
@@ -851,7 +851,7 @@ class Binary(Variable):
         self.symbol -- variable symbol
         """
         self.name = name
-        self.symbol = symbols(name)
+        self.symbol = Symbol(name)
         if unipolar:
             self.type = "b"
         else:
@@ -873,7 +873,7 @@ class Discrete(Variable):
         self.symbol -- variable symbol
         """
         self.name = name
-        self.symbol = symbols(name)
+        self.symbol = Symbol(name)
         self._values = values
         self.type = "d"
         return self.symbol
@@ -936,7 +936,7 @@ class Continuous(Variable):
         self.symbol -- variable symbol
         """
         self.name = name
-        self.symbol = symbols(name)
+        self.symbol = Symbol(name)
         self._min = min_val
         self._max = max_val
         self.precision = precision

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -347,6 +347,36 @@ def test_cost_function() -> None:
     assert dict(sorted(qubo_re.items())) == dict(sorted(reference_qubo_dict_re.items()))
 
 
+def test_variable_names() -> None:
+    """Test for various types of variable names"""
+    variables = Variables()
+    constraint = Constraints()
+    obj_func = ObjectiveFunction()
+    var_names = [
+        "a",
+        "a1",
+        "a_1",
+        "a['1']",
+        "a('1')",
+        "a['0', '1']",
+        "a('0', '1')",
+        "a[('0', '1')]",
+        "a(['0', '1'])",
+        "1a",
+        "['1']a",
+        "['0', '1']a",
+        "(['1'])",
+        "['0', '1']",
+        "('0', '1')"
+    ]
+    for vname in var_names:
+        newvar = variables.add_binary_variable(vname)
+        obj_func.add_objective_function(newvar)
+    variables.move_to_binary(constraint.constraints)
+    qubo = PUBO()
+    qubo = obj_func.rewrite_cost_functions(qubo, variables)
+
+
 def test_cost_function_matrix() -> None:
     """Test for cost function translation"""
     variables = Variables()

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -367,7 +367,7 @@ def test_variable_names() -> None:
         "['0', '1']a",
         "(['1'])",
         "['0', '1']",
-        "('0', '1')"
+        "('0', '1')",
     ]
     for vname in var_names:
         newvar = variables.add_binary_variable(vname)


### PR DESCRIPTION
When creating a variable from pandas data, one may encounter names such as "data['i', 'j']", which previously could not properly be used by the mqt code.

I've made changes to the code and added a test case to confirm its functionality.